### PR TITLE
removes sentry release from github actions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -27,19 +27,3 @@ jobs:
           SENTRY_PROJECT_ID: ${{ secrets.SENTRY_PROJECT }}
           SENTRY_KEY: ${{ secrets.SENTRY_AUTH_TOKEN }}
 
-      - name: Create Deployment
-        id: deploy
-        uses: abendigo/create-deployment@v1
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Create a Sentry.io release
-        uses: getsentry/action-release@v1
-        env:
-          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
-          SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
-          SENTRY_PROJECT: ${{ secrets.SENTRY_PROJECT }}
-          SENTRY_LOG_LEVEL: info
-        with:
-          environment: production
-          version: $(git rev-parse --short HEAD)


### PR DESCRIPTION
i'm removing the sentry release and the github deployment from our deploy.yml because it's unnecessary and also just... doesn't work no matter what i do. we can revisit down the line if we feel it's necessary. sentry releases are _most_ useful for source maps, and workers has no support for that anyway.